### PR TITLE
Use ausaccessfed/aws-cli as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,5 @@
-# Container image that runs your code
-FROM alpine:3.10
+FROM ghcr.io/ausaccessfed/aws-cli:1.1
 
-RUN apk add --no-cache \
-        bash \
-	jq \
-        git \
-        python3 \
-        py3-pip \
-    && pip3 install --upgrade pip \
-    && pip3 install --no-cache-dir \
-        awscli \
-    && rm -rf /var/cache/apk/* \
-    && git config --global user.email "ci@aaf.edu.au" \
-    && git config --global user.name "AAF CI"
-
-# Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
-# Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Resolves #1 

Container image is now based on `ghcr.io/ausaccessfed/aws-cli` which is created [here](https://github.com/ausaccessfed/aws_cli) and published as a publicly accessible image.

Reduces the time spent building `publish_app` from ~30 seconds down to ~7 seconds.