### PR TITLE
Don't try to prevent race conditions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,14 +11,10 @@ inputs:
   environments:
     description: "Comma separated list of environments to deploy image tags to"
     required: true
-  serial_number:
-    description: "Override serial number to prevent overwriting newer images"
-    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.projects }}
     - ${{ inputs.tag }}
-    - ${{ inputs.serial_number }}
     - ${{ inputs.environments }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,12 +6,10 @@ set -e
 
 projects=${1:-$PROJECTS}
 tag=${2:-$IMAGE_TAG}
-serial_number=${3:-$GITHUB_RUN_NUMBER}
-# optional argument to specify which container in the pod (defaults to first)
-environments=${4:-$ENVIRONMENTS}
+environments=${3:-$ENVIRONMENTS}
 
-if [ -z "$serial_number" ]; then
-  echo "Usage: $0 projects tag serial_number environments"
+if [ -z "$environments" ]; then
+  echo "Usage: $0 projects tag environments"
   exit 1
 fi
 
@@ -27,20 +25,7 @@ for project in $(echo $projects | tr "," "\n");
 do
   for environment in $(echo $environments | tr "," "\n");
   do
-    directory="manifests/${project}/overlays/${environment}"
-    serial_number_filename="${directory}/container_${ECR_REPOSITORY}_serial_number.txt"
-    # Ensure we don't accidentally overwrite newer images updates
-    if [ -f "$serial_number_filename" ]; then
-      last_serial_number=$(echo $(<"$serial_number_filename") | sed "s/SERIAL_NUMBER=//")
-      if [ "$last_serial_number" -gt "$serial_number" ]; then
-        echo "Attempted to update image with serial number $serial_number, but previous serial number was $last_serial_number. Image not updated."
-        exit 1
-      fi
-    fi
-
-    echo "SERIAL_NUMBER=$serial_number" > "$serial_number_filename"
-
-    cd $directory
+    cd "manifests/${project}/overlays/${environment}"
     kustomize edit set image $oci_repo_url:$tag
     cd -
   done


### PR DESCRIPTION
We used SERIAL_NUMBER to guard against the possibility of early versions deploying over the top of later versions. The unhappy path looked like this:

- Commit 0 is merged and starts building.
- Commit 1 is merged and starts buidling.
- Commit 1 finishes and the resulting image is deployed.
- Commit 0 finishes and the resulting image is deployed. Oops!

SERIAL_NUMBER prevents this.

However, we've since used [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) to reduce our build minutes. By coincidence, that also prevents the race condition described above, so we don't need SERIAL_NUMBER anymore.